### PR TITLE
Bump Setup Typst to v4

### DIFF
--- a/.github/workflows/build-resume.yml
+++ b/.github/workflows/build-resume.yml
@@ -21,9 +21,9 @@ jobs:
       uses: actions/checkout@v4
       
     - name: Setup Typst
-      uses: yusancky/setup-typst@v2
+      uses: typst-community/setup-typst@v4
       with:
-        version: 'latest'
+        typst-version: 'latest'
     
     - name: Build Resume
       run: |


### PR DESCRIPTION
Bump **[`typst-community/setup-typst`](https://github.com/typst-community/setup-typst)** to v4

> [!WARNING] 
> The action `yusancky/setup-typst` has officially been **migrated** to repository `typst-community/setup-typst`. See [announcement](https://github.com/yusancky/setup-typst/blob/main/announcement.md) for more information.